### PR TITLE
Fix FilterScheme.Update doesn't invoke Updated event.

### DIFF
--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Models/FilterScheme.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Models/FilterScheme.cs
@@ -137,6 +137,7 @@ namespace Orc.FilterBuilder.Models
             Title = otherScheme.Title;
             ConditionItems.Clear();
             ConditionItems.Add(otherScheme.Root);
+            Updated.SafeInvoke(this);
         }
 
         public override string ToString()


### PR DESCRIPTION
If FilterScheme.Update invokes Updated event, it would be easier to detect FilterScheme changes.