### PR TITLE
Fix bug of filter on property not updating in GUI.

### DIFF
--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Models/FilterScheme.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Models/FilterScheme.cs
@@ -101,6 +101,7 @@ namespace Orc.FilterBuilder.Models
 
         protected override void OnDeserialized()
         {
+            this.EnsureIntegrity();
             SubscribeToEvents();
         }
 


### PR DESCRIPTION
After the Filer Scheme is de-serialized filter property needs to be recalled.
Recall of PropertyExpression:Property is delayed in de-serialization. Once a FilterScheme object is de-serialized it needs to be ensured that for each condition tree items / property expression Filter property object is recalled and set. 
Added EnsureIntegrity call in FilterScheme:OnDeserialized() metod before  doing any further operations.