### PR TITLE
Fixed CreateDataTypeExpressionIfNotCompatible to check not only for type but nullability too

### DIFF
--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/DateTimeExpression.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/DateTimeExpression.cs
@@ -12,7 +12,7 @@ namespace Orc.FilterBuilder
     using Orc.FilterBuilder.Models;
 
     [DebuggerDisplay("{ValueControlType} {SelectedCondition} {Value}")]
-    public class DateTimeExpression : DataTypeExpression
+    public class DateTimeExpression : NullableDataTypeExpression
     {
         #region Constructors
         public DateTimeExpression()
@@ -30,8 +30,6 @@ namespace Orc.FilterBuilder
         #endregion
 
         #region Properties
-        public bool IsNullable { get; set; }
-
         public DateTime Value { get; set; }
         #endregion
 

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/DecimalExpression.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/DecimalExpression.cs
@@ -12,7 +12,7 @@ namespace Orc.FilterBuilder
     using Orc.FilterBuilder.Models;
 
     [DebuggerDisplay("{ValueControlType} {SelectedCondition} {Value}")]
-    public class DecimalExpression : DataTypeExpression
+    public class DecimalExpression : NullableDataTypeExpression
     {
         #region Constructors
         public DecimalExpression()
@@ -30,8 +30,6 @@ namespace Orc.FilterBuilder
         #endregion
 
         #region Properties
-        public bool IsNullable { get; set; }
-
         public decimal Value { get; set; }
         #endregion
 

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/DoubleExpression.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/DoubleExpression.cs
@@ -12,7 +12,7 @@ namespace Orc.FilterBuilder
     using Models;
 
     [DebuggerDisplay("{ValueControlType} {SelectedCondition} {Value}")]
-    public class DoubleExpression : DataTypeExpression
+    public class DoubleExpression : NullableDataTypeExpression
     {
         #region Constructors
         public DoubleExpression()
@@ -30,7 +30,6 @@ namespace Orc.FilterBuilder
         #endregion
 
         #region Properties
-        public bool IsNullable { get; set; }
         public double Value { get; set; }
         #endregion
 

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/IntegerExpression.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/IntegerExpression.cs
@@ -12,7 +12,7 @@ namespace Orc.FilterBuilder
     using Orc.FilterBuilder.Models;
 
     [DebuggerDisplay("{ValueControlType} {SelectedCondition} {Value}")]
-    public class IntegerExpression : DataTypeExpression
+    public class IntegerExpression : NullableDataTypeExpression
     {
         #region Constructors
         public IntegerExpression()
@@ -30,8 +30,6 @@ namespace Orc.FilterBuilder
         #endregion
 
         #region Properties
-        public bool IsNullable { get; set; }
-
         public int Value { get; set; }
         #endregion
 

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/NullableDataTypeExpression.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/NullableDataTypeExpression.cs
@@ -1,0 +1,27 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DataTypeExpression.cs" company="WildGums">
+//   Copyright (c) 2008 - 2016 WildGums. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+
+namespace Orc.FilterBuilder
+{
+    using System.Diagnostics;
+    using System.Text;
+    using Catel.Data;
+    using Orc.FilterBuilder.Models;
+
+    public abstract class NullableDataTypeExpression : DataTypeExpression
+    {
+        protected NullableDataTypeExpression()
+            : base()
+        {
+
+        }
+
+        #region Properties
+        public bool IsNullable { get; set; }
+        #endregion
+    }
+}

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/NumericExpression.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/NumericExpression.cs
@@ -12,7 +12,7 @@ namespace Orc.FilterBuilder
     using Models;
 
     [DebuggerDisplay("{ValueControlType} {SelectedCondition} {Value}")]
-    public class NumericExpression : DataTypeExpression
+    public class NumericExpression : NullableDataTypeExpression
     {
         private double _value;
 
@@ -30,8 +30,6 @@ namespace Orc.FilterBuilder
         }
 
         #region Properties
-        public bool IsNullable { get; set; }
-
         public double Value
         {
             get { return _value; }

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/PropertyExpression.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/PropertyExpression.cs
@@ -101,12 +101,19 @@ namespace Orc.FilterBuilder
              where TDataExpression : DataTypeExpression
         {
             var dataTypeExpression = DataTypeExpression;
-            if (dataTypeExpression != null)
+            if (dataTypeExpression != null && dataTypeExpression is TDataExpression)
             {
-                if (dataTypeExpression is TDataExpression)
+                if (dataTypeExpression is NullableDataTypeExpression
+                    && typeof(NullableDataTypeExpression).IsAssignableFromEx(typeof(TDataExpression)))
                 {
-                    return;
+                    var oldDataTypeExpression = dataTypeExpression as NullableDataTypeExpression;
+                    var newDataTypeExpression = createFunc() as NullableDataTypeExpression;
+                    if(newDataTypeExpression.IsNullable != oldDataTypeExpression.IsNullable)
+                    {
+                        DataTypeExpression = newDataTypeExpression;
+                    }
                 }
+                return;
             }
 
             DataTypeExpression = createFunc();

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Orc.FilterBuilder.Shared.projitems
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Orc.FilterBuilder.Shared.projitems
@@ -29,6 +29,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\DecimalExpression.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\DoubleExpression.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\IntegerExpression.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Expressions\NullableDataTypeExpression.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\NumericExpression.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\PropertyExpression.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\StringExpression.cs" />


### PR DESCRIPTION
I hope this is it. We need to check not only for type but for nullability too, otherwise conditions list are not changing correctly (in combobox).