### PR TITLE
Linq Expression Feature

### DIFF
--- a/src/Orc.FilterBuilder.Tests/Orc.FilterBuilder.Tests.Shared/Models/FilterSchemeFacts.cs
+++ b/src/Orc.FilterBuilder.Tests/Orc.FilterBuilder.Tests.Shared/Models/FilterSchemeFacts.cs
@@ -7,6 +7,9 @@
 
 namespace Orc.FilterBuilder.Tests.Shared.Models
 {
+    using System.Collections.Generic;
+    using System.Linq;
+
     using FilterBuilder.Models;
     using NUnit.Framework;
     using Tests.Models;
@@ -40,6 +43,20 @@ namespace Orc.FilterBuilder.Tests.Shared.Models
 (StringProperty contains '123' and BoolProperty is equal to 'True' and IntProperty is greater than or equal to '42') and (StringProperty contains '123' and BoolProperty is equal to 'True' and IntProperty is greater than or equal to '42')";
 
                 Assert.AreEqual(expected, actual);
+            }
+
+            [TestCase]
+            public void CalculateResultEqualsLinqResultOnFilterScheme()
+            {
+                var filterScheme = FilterSchemeHelper.GenerateFilterScheme();
+                var testCollection = FilterSchemeHelper.GenerateMatchingAndNonMatchingCollection();
+
+                var linqLambdaExpression = filterScheme.ToLinqExpression<TestFilterModel>();
+
+                var filterSchemeCollection = testCollection.Where(item => filterScheme.CalculateResult(item));
+                var linqCollection = testCollection.Where(linqLambdaExpression.Compile());
+
+                CollectionAssert.AreEqual(filterSchemeCollection, linqCollection);
             }
         }
     }

--- a/src/Orc.FilterBuilder.Tests/Orc.FilterBuilder.Tests.Shared/Models/FilterSchemeFacts.cs
+++ b/src/Orc.FilterBuilder.Tests/Orc.FilterBuilder.Tests.Shared/Models/FilterSchemeFacts.cs
@@ -40,7 +40,7 @@ namespace Orc.FilterBuilder.Tests.Shared.Models
 
                 var actual = filterScheme.ToString();
                 var expected = @"Test filter
-(StringProperty contains '123' and BoolProperty is equal to 'True' and IntProperty is greater than or equal to '42') and (StringProperty contains '123' and BoolProperty is equal to 'True' and IntProperty is greater than or equal to '42')";
+(StringProperty contains '123' and StringProperty is not null '' and BoolProperty is equal to 'True' and IntProperty is greater than or equal to '42') and (StringProperty contains '123' and StringProperty is not null '' and BoolProperty is equal to 'True' and IntProperty is greater than or equal to '42')";
 
                 Assert.AreEqual(expected, actual);
             }
@@ -57,6 +57,8 @@ namespace Orc.FilterBuilder.Tests.Shared.Models
                 var linqCollection = testCollection.Where(linqLambdaExpression.Compile());
 
                 CollectionAssert.AreEqual(filterSchemeCollection, linqCollection);
+                Assert.AreEqual(testCollection.Count() - linqCollection.Count(), FilterSchemeHelper.NonMatchingCount);
+                Assert.AreEqual(linqCollection.Count(), FilterSchemeHelper.MatchingCount);
             }
         }
     }

--- a/src/Orc.FilterBuilder.Tests/Orc.FilterBuilder.Tests.Shared/Models/Helpers/FilterSchemeHelper.cs
+++ b/src/Orc.FilterBuilder.Tests/Orc.FilterBuilder.Tests.Shared/Models/Helpers/FilterSchemeHelper.cs
@@ -7,6 +7,7 @@
 
 namespace Orc.FilterBuilder.Tests.Models
 {
+    using System.Collections.Generic;
     using System.Linq;
     using Catel.Data;
     using FilterBuilder.Models;
@@ -14,6 +15,45 @@ namespace Orc.FilterBuilder.Tests.Models
 
     public static class FilterSchemeHelper
     {
+        public static IEnumerable<TestFilterModel> GenerateMatchingAndNonMatchingCollection()
+        {
+            List<TestFilterModel> testCollection = new List<TestFilterModel>();
+
+            // Matching value
+            testCollection.Add(new TestFilterModel
+            {
+                BoolProperty = true,
+                IntProperty = 50,
+                StringProperty = "Test va123lue"
+            });
+
+            // Non-Matching value
+            testCollection.Add(new TestFilterModel
+            {
+                BoolProperty = false,
+                IntProperty = null,
+                StringProperty = "Test va123lue"
+            });
+
+            // Matching value
+            testCollection.Add(new TestFilterModel
+            {
+                BoolProperty = true,
+                IntProperty = 42,
+                StringProperty = "123lue"
+            });
+
+            // Non-Matching value
+            testCollection.Add(new TestFilterModel
+            {
+                BoolProperty = true,
+                IntProperty = 50,
+                StringProperty = "Test value"
+            });
+
+            return testCollection;
+        }
+
         public static FilterScheme GenerateFilterScheme()
         {
             var filterScheme = new FilterScheme();

--- a/src/Orc.FilterBuilder.Tests/Orc.FilterBuilder.Tests.Shared/Models/Helpers/FilterSchemeHelper.cs
+++ b/src/Orc.FilterBuilder.Tests/Orc.FilterBuilder.Tests.Shared/Models/Helpers/FilterSchemeHelper.cs
@@ -15,6 +15,9 @@ namespace Orc.FilterBuilder.Tests.Models
 
     public static class FilterSchemeHelper
     {
+        public const int MatchingCount = 2;
+        public const int NonMatchingCount = 3;
+
         public static IEnumerable<TestFilterModel> GenerateMatchingAndNonMatchingCollection()
         {
             List<TestFilterModel> testCollection = new List<TestFilterModel>();
@@ -51,6 +54,14 @@ namespace Orc.FilterBuilder.Tests.Models
                 StringProperty = "Test value"
             });
 
+            // Non-Matching value
+            testCollection.Add(new TestFilterModel
+            {
+                BoolProperty = true,
+                IntProperty = 50,
+                StringProperty = null
+            });
+
             return testCollection;
         }
 
@@ -73,8 +84,9 @@ namespace Orc.FilterBuilder.Tests.Models
             {
                 Type = ConditionGroupType.And
             };
-
+      
             conditionGroup.Items.Add(GenerateStringExpression());
+            //conditionGroup.Items.Add(GenerateNonNullStringExpression());
             conditionGroup.Items.Add(GenerateBoolExpression());
             conditionGroup.Items.Add(GenerateIntExpression());
 
@@ -89,6 +101,21 @@ namespace Orc.FilterBuilder.Tests.Models
             var expression = GenerateExpression<StringExpression>();
             expression.SelectedCondition = Condition.Contains;
             expression.Value = "123";
+
+            var propertyExpression = new PropertyExpression();
+            propertyExpression.Property = new PropertyMetadata(typeof(TestFilterModel), typeInfo.GetPropertyData("StringProperty"));
+            propertyExpression.DataTypeExpression = expression;
+
+            return propertyExpression;
+        }
+
+        public static PropertyExpression GenerateNonNullStringExpression()
+        {
+            var propertyDataManager = PropertyDataManager.Default;
+            var typeInfo = propertyDataManager.GetCatelTypeInfo(typeof(TestFilterModel));
+
+            var expression = GenerateExpression<StringExpression>();
+            expression.SelectedCondition = Condition.NotIsNull;
 
             var propertyExpression = new PropertyExpression();
             propertyExpression.Property = new PropertyMetadata(typeof(TestFilterModel), typeInfo.GetPropertyData("StringProperty"));

--- a/src/Orc.FilterBuilder.Tests/Orc.FilterBuilder.Tests.Shared/Models/Helpers/FilterSchemeHelper.cs
+++ b/src/Orc.FilterBuilder.Tests/Orc.FilterBuilder.Tests.Shared/Models/Helpers/FilterSchemeHelper.cs
@@ -86,7 +86,7 @@ namespace Orc.FilterBuilder.Tests.Models
             };
       
             conditionGroup.Items.Add(GenerateStringExpression());
-            //conditionGroup.Items.Add(GenerateNonNullStringExpression());
+            conditionGroup.Items.Add(GenerateNonNullStringExpression());
             conditionGroup.Items.Add(GenerateBoolExpression());
             conditionGroup.Items.Add(GenerateIntExpression());
 

--- a/src/Orc.FilterBuilder.Tests/Orc.FilterBuilder.Tests.Shared/Models/TestFilterModel.cs
+++ b/src/Orc.FilterBuilder.Tests/Orc.FilterBuilder.Tests.Shared/Models/TestFilterModel.cs
@@ -15,6 +15,6 @@ namespace Orc.FilterBuilder.Tests.Models
 
         public bool BoolProperty { get; set; }
 
-        public int IntProperty { get; set; }
+        public int? IntProperty { get; set; }
     }
 }

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Conditions/ConditionGroup.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Conditions/ConditionGroup.cs
@@ -1,13 +1,14 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ConditionGroup.cs" company="WildGums">
-//   Copyright (c) 2008 - 2014 WildGums. All rights reserved.
+//   Copyright (c) 2008 - 2016 WildGums. All rights reserved.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-
 namespace Orc.FilterBuilder
 {
+    using System;
     using System.Linq;
+    using System.Linq.Expressions;
     using System.Text;
 
     public class ConditionGroup : ConditionTreeItem
@@ -19,9 +20,13 @@ namespace Orc.FilterBuilder
         }
         #endregion
 
+
+
         #region Properties
         public ConditionGroupType Type { get; set; }
         #endregion
+
+
 
         #region Methods
         public override bool CalculateResult(object entity)
@@ -39,6 +44,47 @@ namespace Orc.FilterBuilder
             {
                 return Items.Aggregate(false, (current, item) => current || item.CalculateResult(entity));
             }
+        }
+
+        /// <summary>
+        ///   Converts <see cref="ConditionTreeItem"/> to a LINQ <see cref="Expression"/>
+        /// </summary>
+        /// <param name="parameterExpr">LINQ <see cref="ParameterExpression"/>.</param>
+        /// <returns>LINQ Expression.</returns>
+        public override Expression ToLinqExpression(Expression parameterExpr)
+        {
+            if (!Items.Any())
+            {
+                return Expression.Constant(true, typeof(bool));
+            }
+
+            var lastExpr = Items.First().ToLinqExpression(parameterExpr);
+
+            if (Items.Count <= 1)
+            {
+                return lastExpr;
+            }
+
+            for (int i = 1; i < Items.Count; i++)
+            {
+                var rightExpr = Items[i].ToLinqExpression(parameterExpr);
+
+                switch (Type)
+                {
+                    case ConditionGroupType.And:
+                        lastExpr = Expression.AndAlso(lastExpr, rightExpr);
+                        break;
+
+                    case ConditionGroupType.Or:
+                        lastExpr = Expression.OrElse(lastExpr, rightExpr);
+                        break;
+
+                    default:
+                        throw new InvalidOperationException($"Unsupported ConditionGroupType: {Type}");
+                }
+            }
+
+            return lastExpr;
         }
 
         public override string ToString()

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Conditions/ConditionGroup.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Conditions/ConditionGroup.cs
@@ -10,7 +10,9 @@ namespace Orc.FilterBuilder
     using System.Linq;
     using System.Linq.Expressions;
     using System.Text;
-
+  
+    using Catel;
+  
     public class ConditionGroup : ConditionTreeItem
     {
         #region Constructors
@@ -53,6 +55,8 @@ namespace Orc.FilterBuilder
         /// <returns>LINQ Expression.</returns>
         public override Expression ToLinqExpression(Expression parameterExpr)
         {
+            Argument.IsNotNull(() => parameterExpr);
+
             if (!Items.Any())
             {
                 return Expression.Constant(true, typeof(bool));

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Conditions/ConditionTreeItem.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Conditions/ConditionTreeItem.cs
@@ -1,9 +1,8 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ConditionTreeItem.cs" company="WildGums">
-//   Copyright (c) 2008 - 2014 WildGums. All rights reserved.
+//   Copyright (c) 2008 - 2016 WildGums. All rights reserved.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-
 
 namespace Orc.FilterBuilder
 {
@@ -11,11 +10,11 @@ namespace Orc.FilterBuilder
     using System.Collections;
     using System.Collections.ObjectModel;
     using System.Collections.Specialized;
+    using System.Linq.Expressions;
+
     using Catel;
     using Catel.Data;
-    using Catel.IoC;
     using Catel.Runtime.Serialization;
-    using Services;
 
     public abstract class ConditionTreeItem : ModelBase
     {
@@ -25,6 +24,8 @@ namespace Orc.FilterBuilder
             Items = new ObservableCollection<ConditionTreeItem>();
         }
         #endregion
+
+
 
         #region Properties
         [ExcludeFromSerialization]
@@ -37,7 +38,7 @@ namespace Orc.FilterBuilder
         public ObservableCollection<ConditionTreeItem> Items { get; private set; }
         #endregion
 
-        public event EventHandler<EventArgs> Updated;
+
 
         #region Methods
         private void OnConditionItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -126,6 +127,13 @@ namespace Orc.FilterBuilder
 
         public abstract bool CalculateResult(object entity);
 
+        /// <summary>
+        ///   Converts <see cref="ConditionTreeItem"/> to a LINQ <see cref="Expression"/>
+        /// </summary>
+        /// <param name="parameterExpr">LINQ ParameterExpression.</param>
+        /// <returns>LINQ Expression.</returns>
+        public abstract Expression ToLinqExpression(Expression parameterExpr);
+
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(obj, this))
@@ -141,5 +149,9 @@ namespace Orc.FilterBuilder
             return base.GetHashCode();
         }
         #endregion
+
+
+
+        public event EventHandler<EventArgs> Updated;
     }
 }

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/BooleanExpression.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/BooleanExpression.cs
@@ -11,6 +11,7 @@ namespace Orc.FilterBuilder
     using System.Diagnostics;
     using System.Linq.Expressions;
 
+    using Catel;
     using Catel.Runtime.Serialization;
 
     using Orc.FilterBuilder.Models;
@@ -60,6 +61,8 @@ namespace Orc.FilterBuilder
         /// <returns>LINQ Expression.</returns>
         public override Expression ToLinqExpression(Expression propertyExpr)
         {
+            Argument.IsNotNull(() => propertyExpr);
+
             var valueExpr = Expression.Constant(Value, typeof(bool));
 
             return Expression.Equal(propertyExpr, valueExpr);

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/BooleanExpression.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/BooleanExpression.cs
@@ -1,16 +1,18 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="BooleanExpression.cs" company="WildGums">
-//   Copyright (c) 2008 - 2014 WildGums. All rights reserved.
+//   Copyright (c) 2008 - 2016 WildGums. All rights reserved.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-
 
 namespace Orc.FilterBuilder
 {
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Linq.Expressions;
+
     using Catel.Runtime.Serialization;
+
     using Orc.FilterBuilder.Models;
 
     [DebuggerDisplay("{ValueControlType} {SelectedCondition} {Value}")]
@@ -19,12 +21,14 @@ namespace Orc.FilterBuilder
         #region Constructors
         public BooleanExpression()
         {
-            BooleanValues = new List<bool> {true, false};
+            BooleanValues = new List<bool> { true, false };
             Value = true;
             SelectedCondition = Condition.EqualTo;
             ValueControlType = ValueControlType.Boolean;
         }
         #endregion
+
+
 
         #region Properties
         public bool Value { get; set; }
@@ -32,6 +36,8 @@ namespace Orc.FilterBuilder
         [ExcludeFromSerialization]
         public List<bool> BooleanValues { get; set; }
         #endregion
+
+
 
         #region Methods
         public override bool CalculateResult(IPropertyMetadata propertyMetadata, object entity)
@@ -45,6 +51,18 @@ namespace Orc.FilterBuilder
                 default:
                     throw new NotSupportedException(string.Format("Condition '{0}' is not supported.", SelectedCondition));
             }
+        }
+
+        /// <summary>
+        ///   Converts <see cref="ConditionTreeItem"/> to a LINQ <see cref="Expression"/>
+        /// </summary>
+        /// <param name="propertyExpr">LINQ <see cref="MemberExpression"/>.</param>
+        /// <returns>LINQ Expression.</returns>
+        public override Expression ToLinqExpression(Expression propertyExpr)
+        {
+            var valueExpr = Expression.Constant(Value, typeof(bool));
+
+            return Expression.Equal(propertyExpr, valueExpr);
         }
 
         public override string ToString()

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/DataTypeExpression.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/DataTypeExpression.cs
@@ -1,23 +1,27 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DataTypeExpression.cs" company="WildGums">
-//   Copyright (c) 2008 - 2014 WildGums. All rights reserved.
+//   Copyright (c) 2008 - 2016 WildGums. All rights reserved.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-
 namespace Orc.FilterBuilder
 {
-    using System.Diagnostics;
-    using System.Text;
+    using System.Linq.Expressions;
+
     using Catel.Data;
+
     using Orc.FilterBuilder.Models;
 
     public abstract class DataTypeExpression : ModelBase
     {
+        #region Constructors
         protected DataTypeExpression()
         {
             IsValueRequired = true;
         }
+        #endregion
+
+
 
         #region Properties
         public Condition SelectedCondition { get; set; }
@@ -27,6 +31,8 @@ namespace Orc.FilterBuilder
         public ValueControlType ValueControlType { get; set; }
         #endregion
 
+
+
         #region Methods
         private void OnSelectedConditionChanged()
         {
@@ -34,6 +40,13 @@ namespace Orc.FilterBuilder
         }
 
         public abstract bool CalculateResult(IPropertyMetadata propertyMetadata, object entity);
+
+        /// <summary>
+        ///   Converts <see cref="ConditionTreeItem"/> to a LINQ <see cref="Expression"/>
+        /// </summary>
+        /// <param name="propertyExpr">LINQ <see cref="MemberExpression"/>.</param>
+        /// <returns>LINQ Expression.</returns>
+        public abstract Expression ToLinqExpression(Expression propertyExpr);
         #endregion
     }
 }

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/PropertyExpression.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/PropertyExpression.cs
@@ -11,6 +11,7 @@ namespace Orc.FilterBuilder
     using System.Diagnostics;
     using System.Linq.Expressions;
 
+    using Catel;
     using Catel.Data;
     using Catel.Logging;
     using Catel.Reflection;
@@ -247,6 +248,8 @@ namespace Orc.FilterBuilder
         /// <returns>LINQ Expression.</returns>
         public override Expression ToLinqExpression(Expression parameterExpr)
         {
+            Argument.IsNotNull(() => parameterExpr);
+
             if (!IsValid)
             {
                 return Expression.Constant(true, typeof(bool));

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/PropertyExpression.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/PropertyExpression.cs
@@ -1,28 +1,34 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PropertyExpression.cs" company="WildGums">
-//   Copyright (c) 2008 - 2014 WildGums. All rights reserved.
+//   Copyright (c) 2008 - 2016 WildGums. All rights reserved.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-
 
 namespace Orc.FilterBuilder
 {
     using System;
     using System.ComponentModel;
     using System.Diagnostics;
-    using Catel.Reflection;
-    using Catel.Runtime.Serialization;
-    using Models;
-    using Runtime.Serialization;
+    using System.Linq.Expressions;
+
     using Catel.Data;
     using Catel.Logging;
+    using Catel.Reflection;
+    using Catel.Runtime.Serialization;
+
+    using Orc.FilterBuilder.Models;
+    using Orc.FilterBuilder.Runtime.Serialization;
 
     [DebuggerDisplay("{Property} = {DataTypeExpression}")]
     [SerializerModifier(typeof(PropertyExpressionSerializerModifier))]
     [ValidateModel(typeof(PropertyExpressionValidator))]
     public class PropertyExpression : ConditionTreeItem
     {
-        private static ILog Log = LogManager.GetCurrentClassLogger();
+        #region Constants
+        private static readonly ILog Log = LogManager.GetCurrentClassLogger();
+        #endregion
+
+
 
         #region Constructors
         public PropertyExpression()
@@ -30,6 +36,8 @@ namespace Orc.FilterBuilder
             SuspendValidation = false;
         }
         #endregion
+
+
 
         #region Properties
         [ExcludeFromSerialization]
@@ -39,6 +47,8 @@ namespace Orc.FilterBuilder
 
         public DataTypeExpression DataTypeExpression { get; set; }
         #endregion
+
+
 
         #region Methods
         private void OnPropertyChanged()
@@ -180,14 +190,12 @@ namespace Orc.FilterBuilder
             }
         }
 
-        private void CreateDataTypeExpressionIfNotCompatible<TDataExpression>(Func<TDataExpression> createFunc)
-             where TDataExpression : DataTypeExpression
+        private void CreateDataTypeExpressionIfNotCompatible<TDataExpression>(Func<TDataExpression> createFunc) where TDataExpression : DataTypeExpression
         {
             var dataTypeExpression = DataTypeExpression;
             if (dataTypeExpression != null && dataTypeExpression is TDataExpression)
             {
-                if (dataTypeExpression is NullableDataTypeExpression
-                    && typeof(NullableDataTypeExpression).IsAssignableFromEx(typeof(TDataExpression)))
+                if (dataTypeExpression is NullableDataTypeExpression && typeof(NullableDataTypeExpression).IsAssignableFromEx(typeof(TDataExpression)))
                 {
                     var oldDataTypeExpression = dataTypeExpression as NullableDataTypeExpression;
                     var newDataTypeExpression = createFunc() as NullableDataTypeExpression;
@@ -230,6 +238,23 @@ namespace Orc.FilterBuilder
             }
 
             return DataTypeExpression.CalculateResult(Property, entity);
+        }
+
+        /// <summary>
+        ///   Converts <see cref="ConditionTreeItem"/> to a LINQ <see cref="Expression"/>
+        /// </summary>
+        /// <param name="parameterExpr">LINQ <see cref="ParameterExpression"/>.</param>
+        /// <returns>LINQ Expression.</returns>
+        public override Expression ToLinqExpression(Expression parameterExpr)
+        {
+            if (!IsValid)
+            {
+                return Expression.Constant(true, typeof(bool));
+            }
+
+            var propExpr = Expression.Property(parameterExpr, parameterExpr.Type, Property.Name);
+
+            return DataTypeExpression.ToLinqExpression(propExpr);
         }
 
         public override string ToString()

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/StringExpression.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/StringExpression.cs
@@ -29,12 +29,13 @@ namespace Orc.FilterBuilder
         private const string ContainsMethodName = "Contains";
         private const string StartsWithMethodName = "StartsWith";
         private const string EndsWithMethodName = "EndsWith";
+        private const string CompareMethodName = "Compare";
         #endregion
 
 
 
-        #region Constructors
-        public StringExpression()
+    #region Constructors
+    public StringExpression()
         {
             SelectedCondition = Condition.Contains;
             Value = string.Empty;
@@ -205,16 +206,16 @@ namespace Orc.FilterBuilder
                                    .IsMatch(entityValue);
                                    */
                 case Condition.GreaterThan:
-                    return Expression.GreaterThan(Expression.Call(Expression.Constant(null, typeof(string)), typeof(string).GetMethodEx("Compare", comparisonMethodParams), propertyExpr, valueExpr, Expression.Constant(StringComparison.CurrentCultureIgnoreCase)), Expression.Constant(0, typeof(int)));
+                    return Expression.GreaterThan(Expression.Call(Expression.Constant(null, typeof(string)), typeof(string).GetMethodEx(CompareMethodName, comparisonMethodParams), propertyExpr, valueExpr, Expression.Constant(StringComparison.CurrentCultureIgnoreCase)), Expression.Constant(0, typeof(int)));
 
                 case Condition.GreaterThanOrEqualTo:
-                    return Expression.GreaterThanOrEqual(Expression.Call(Expression.Constant(null, typeof(string)), typeof(string).GetMethodEx("Compare", comparisonMethodParams), propertyExpr, valueExpr, Expression.Constant(StringComparison.CurrentCultureIgnoreCase)), Expression.Constant(0, typeof(int)));
+                    return Expression.GreaterThanOrEqual(Expression.Call(Expression.Constant(null, typeof(string)), typeof(string).GetMethodEx(CompareMethodName, comparisonMethodParams), propertyExpr, valueExpr, Expression.Constant(StringComparison.CurrentCultureIgnoreCase)), Expression.Constant(0, typeof(int)));
 
                 case Condition.LessThan:
-                    return Expression.LessThan(Expression.Call(Expression.Constant(null, typeof(string)), typeof(string).GetMethodEx("Compare", comparisonMethodParams), propertyExpr, valueExpr, Expression.Constant(StringComparison.CurrentCultureIgnoreCase)), Expression.Constant(0, typeof(int)));
+                    return Expression.LessThan(Expression.Call(Expression.Constant(null, typeof(string)), typeof(string).GetMethodEx(CompareMethodName, comparisonMethodParams), propertyExpr, valueExpr, Expression.Constant(StringComparison.CurrentCultureIgnoreCase)), Expression.Constant(0, typeof(int)));
 
                 case Condition.LessThanOrEqualTo:
-                    return Expression.LessThanOrEqual(Expression.Call(Expression.Constant(null, typeof(string)), typeof(string).GetMethodEx("Compare", comparisonMethodParams), propertyExpr, valueExpr, Expression.Constant(StringComparison.CurrentCultureIgnoreCase)), Expression.Constant(0, typeof(int)));
+                    return Expression.LessThanOrEqual(Expression.Call(Expression.Constant(null, typeof(string)), typeof(string).GetMethodEx(CompareMethodName, comparisonMethodParams), propertyExpr, valueExpr, Expression.Constant(StringComparison.CurrentCultureIgnoreCase)), Expression.Constant(0, typeof(int)));
 
                 default:
                     throw new NotSupportedException(string.Format("Condition '{0}' is not supported.", SelectedCondition));

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/StringExpression.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/StringExpression.cs
@@ -1,30 +1,32 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="StringExpression.cs" company="WildGums">
-//   Copyright (c) 2008 - 2014 WildGums. All rights reserved.
+//   Copyright (c) 2008 - 2016 WildGums. All rights reserved.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-
 namespace Orc.FilterBuilder
 {
-    using Catel.Reflection;
-    using Orc.FilterBuilder.Models;
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Linq.Expressions;
     using System.Text.RegularExpressions;
+
     using Catel.Caching;
     using Catel.Caching.Policies;
-    using Catel.Data;
-    using System.Collections.Generic;
-    using System.ComponentModel.DataAnnotations;
+    using Catel.Reflection;
+
+    using Orc.FilterBuilder.Models;
 
     [DebuggerDisplay("{ValueControlType} {SelectedCondition} {Value}")]
     public class StringExpression : DataTypeExpression
     {
-        #region Fields
+        #region Constants
         private static readonly CacheStorage<string, Regex> _regexCache = new CacheStorage<string, Regex>(() => ExpirationPolicy.Sliding(TimeSpan.FromMinutes(1)), false, EqualityComparer<string>.Default);
         private static readonly CacheStorage<string, bool> _regexIsValidCache = new CacheStorage<string, bool>(() => ExpirationPolicy.Sliding(TimeSpan.FromMinutes(1)), false, EqualityComparer<string>.Default);
         #endregion
+
+
 
         #region Constructors
         public StringExpression()
@@ -35,9 +37,13 @@ namespace Orc.FilterBuilder
         }
         #endregion
 
+
+
         #region Properties
         public string Value { get; set; }
         #endregion
+
+
 
         #region Methods
         public override bool CalculateResult(IPropertyMetadata propertyMetadata, object entity)
@@ -103,18 +109,118 @@ namespace Orc.FilterBuilder
                     return entityValue != null && !entityValue.StartsWith(Value, StringComparison.CurrentCultureIgnoreCase);
 
                 case Condition.Matches:
-                    return entityValue != null
-                        && _regexIsValidCache.GetFromCacheOrFetch(Value, () => RegexHelper.IsValid(Value))
-                        && _regexCache.GetFromCacheOrFetch(Value, () => new Regex(Value, RegexOptions.Compiled)).IsMatch(entityValue);
+                    return entityValue != null && _regexIsValidCache.GetFromCacheOrFetch(Value, () => RegexHelper.IsValid(Value)) && _regexCache.GetFromCacheOrFetch(Value, () => new Regex(Value, RegexOptions.Compiled)).IsMatch(entityValue);
 
                 case Condition.DoesNotMatch:
-                    return entityValue != null
-                        && _regexIsValidCache.GetFromCacheOrFetch(Value, () => RegexHelper.IsValid(Value))
-                        && !_regexCache.GetFromCacheOrFetch(Value, () => new Regex(Value, RegexOptions.Compiled)).IsMatch(entityValue);
+                    return entityValue != null && _regexIsValidCache.GetFromCacheOrFetch(Value, () => RegexHelper.IsValid(Value)) && !_regexCache.GetFromCacheOrFetch(Value, () => new Regex(Value, RegexOptions.Compiled)).IsMatch(entityValue);
 
                 default:
                     throw new NotSupportedException(string.Format("Condition '{0}' is not supported.", SelectedCondition));
             }
+        }
+
+        /// <summary>
+        ///   Converts <see cref="ConditionTreeItem"/> to a LINQ <see cref="Expression"/>
+        /// </summary>
+        /// <param name="propertyExpr">LINQ <see cref="MemberExpression"/>.</param>
+        /// <returns>LINQ Expression.</returns>
+        public override Expression ToLinqExpression(Expression propertyExpr)
+        {
+            // Check non-value condition types
+            switch (SelectedCondition)
+            {
+                case Condition.IsEmpty:
+                    return Expression.Equal(propertyExpr, Expression.Constant(string.Empty));
+                case Condition.NotIsEmpty:
+                    return Expression.NotEqual(propertyExpr, Expression.Constant(string.Empty));
+                case Condition.IsNull:
+                    return Expression.Equal(propertyExpr, Expression.Constant(null));
+                case Condition.NotIsNull:
+                    return Expression.NotEqual(propertyExpr, Expression.Constant(null));
+            }
+
+            // Check value condition types
+            var valueExpr = Expression.Constant(Value, typeof(string));
+            Expression operatorExpr = null;
+
+            Type[] comparisonMethodParams = { typeof(string), typeof(string), typeof(StringComparison) };
+
+            switch (SelectedCondition)
+            {
+                case Condition.EqualTo:
+                    return Expression.Equal(propertyExpr, valueExpr);
+
+                case Condition.NotEqualTo:
+                    return Expression.NotEqual(propertyExpr, valueExpr);
+
+                case Condition.Contains:
+                    operatorExpr = Expression.Call(propertyExpr, typeof(string).GetMethod("Contains", new[] { typeof(string) }), valueExpr);
+                    break;
+
+                case Condition.DoesNotContain:
+                    operatorExpr = Expression.IsFalse(Expression.Call(propertyExpr, typeof(string).GetMethod("Contains", new[] { typeof(string) }), valueExpr));
+                    break;
+
+                case Condition.StartsWith:
+                    operatorExpr = Expression.Call(propertyExpr, typeof(string).GetMethod("StartsWith", new[] { typeof(string), typeof(StringComparison) }), valueExpr, Expression.Constant(StringComparison.CurrentCultureIgnoreCase));
+                    break;
+
+                case Condition.DoesNotStartWith:
+                    operatorExpr = Expression.IsFalse(Expression.Call(propertyExpr, typeof(string).GetMethod("StartsWith", new[] { typeof(string), typeof(StringComparison) }), valueExpr, Expression.Constant(StringComparison.CurrentCultureIgnoreCase)));
+                    break;
+
+                case Condition.EndsWith:
+                    operatorExpr = Expression.Call(propertyExpr, typeof(string).GetMethod("EndsWith", new[] { typeof(string), typeof(StringComparison) }), valueExpr, Expression.Constant(StringComparison.CurrentCultureIgnoreCase));
+                    break;
+
+                case Condition.DoesNotEndWith:
+                    operatorExpr = Expression.IsFalse(Expression.Call(propertyExpr, typeof(string).GetMethod("EndsWith", new[] { typeof(string), typeof(StringComparison) }), valueExpr, Expression.Constant(StringComparison.CurrentCultureIgnoreCase)));
+                    break;
+
+                // TODO: Handle REGEXP
+                /*
+              case Condition.Matches:
+                return entityValue != null
+                       &&
+                       _regexIsValidCache.GetFromCacheOrFetch(Value,
+                         () => RegexHelper.IsValid(Value))
+                       &&
+                       _regexCache.GetFromCacheOrFetch(Value, () => new Regex(Value))
+                                  .IsMatch(entityValue);
+
+              case Condition.DoesNotMatch:
+                return entityValue != null
+                       &&
+                       _regexIsValidCache.GetFromCacheOrFetch(Value,
+                         () => RegexHelper.IsValid(Value))
+                       &&
+                       !_regexCache.GetFromCacheOrFetch(Value, () => new Regex(Value))
+                                   .IsMatch(entityValue);
+                                   */
+                case Condition.GreaterThan:
+                    return Expression.GreaterThan(Expression.Call(Expression.Constant(null, typeof(string)), typeof(string).GetMethod("Compare", comparisonMethodParams), propertyExpr, valueExpr, Expression.Constant(StringComparison.CurrentCultureIgnoreCase)), Expression.Constant(0, typeof(int)));
+
+                case Condition.GreaterThanOrEqualTo:
+                    return Expression.GreaterThanOrEqual(Expression.Call(Expression.Constant(null, typeof(string)), typeof(string).GetMethod("Compare", comparisonMethodParams), propertyExpr, valueExpr, Expression.Constant(StringComparison.CurrentCultureIgnoreCase)), Expression.Constant(0, typeof(int)));
+
+                case Condition.LessThan:
+                    return Expression.LessThan(Expression.Call(Expression.Constant(null, typeof(string)), typeof(string).GetMethod("Compare", comparisonMethodParams), propertyExpr, valueExpr, Expression.Constant(StringComparison.CurrentCultureIgnoreCase)), Expression.Constant(0, typeof(int)));
+
+                case Condition.LessThanOrEqualTo:
+                    return Expression.LessThanOrEqual(Expression.Call(Expression.Constant(null, typeof(string)), typeof(string).GetMethod("Compare", comparisonMethodParams), propertyExpr, valueExpr, Expression.Constant(StringComparison.CurrentCultureIgnoreCase)), Expression.Constant(0, typeof(int)));
+
+                default:
+                    throw new NotSupportedException(string.Format("Condition '{0}' is not supported.", SelectedCondition));
+            }
+
+            return CreateNullCheckExpression(propertyExpr, operatorExpr);
+        }
+
+        private Expression CreateNullCheckExpression(Expression propExpr, Expression operatorExpr)
+        {
+            Expression nullCheckExpr = Expression.ReferenceNotEqual(propExpr, Expression.Constant(null));
+
+            return Expression.AndAlso(nullCheckExpr, operatorExpr);
         }
 
         public override string ToString()

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/TimeSpanExpression.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/TimeSpanExpression.cs
@@ -13,6 +13,7 @@ namespace Orc.FilterBuilder
     using System.Linq;
     using System.Linq.Expressions;
 
+    using Catel;
     using Catel.Data;
     using Catel.Runtime.Serialization;
 
@@ -131,6 +132,8 @@ namespace Orc.FilterBuilder
         /// <returns>LINQ Expression.</returns>
         public override Expression ToLinqExpression(Expression propertyExpr)
         {
+            Argument.IsNotNull(() => propertyExpr);
+
             var valueExpr = Expression.Constant(Value, typeof(TimeSpan));
 
             // Operators

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/TimeSpanExpression.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/TimeSpanExpression.cs
@@ -1,9 +1,8 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="TimeSpanExpression.cs" company="WildGums">
-//   Copyright (c) 2008 - 2014 WildGums. All rights reserved.
+//   Copyright (c) 2008 - 2016 WildGums. All rights reserved.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-
 
 namespace Orc.FilterBuilder
 {
@@ -12,8 +11,11 @@ namespace Orc.FilterBuilder
     using System.ComponentModel;
     using System.Diagnostics;
     using System.Linq;
+    using System.Linq.Expressions;
+
     using Catel.Data;
     using Catel.Runtime.Serialization;
+
     using Orc.FilterBuilder.Models;
 
     [DebuggerDisplay("{ValueControlType} {SelectedCondition} {Value}")]
@@ -24,12 +26,10 @@ namespace Orc.FilterBuilder
         private const int AverageDaysInMonth = 30;
         #endregion
 
+
+
         #region Constructors
-        public TimeSpanExpression()
-            : this(true)
-        {
-            
-        }
+        public TimeSpanExpression() : this(true) { }
 
         public TimeSpanExpression(bool isNullable)
         {
@@ -37,10 +37,12 @@ namespace Orc.FilterBuilder
             SelectedCondition = Condition.EqualTo;
             Value = TimeSpan.FromHours(1);
             ValueControlType = ValueControlType.TimeSpan;
-            SpanTypes = Enum.GetValues(typeof (TimeSpanType)).Cast<TimeSpanType>().ToList();
+            SpanTypes = Enum.GetValues(typeof(TimeSpanType)).Cast<TimeSpanType>().ToList();
             SelectedSpanType = TimeSpanType.Hours;
         }
         #endregion
+
+
 
         #region Properties
         public TimeSpan Value { get; set; }
@@ -52,6 +54,8 @@ namespace Orc.FilterBuilder
 
         public float Amount { get; set; }
         #endregion
+
+
 
         #region Methods
         protected override void OnPropertyChanged(AdvancedPropertyChangedEventArgs e)
@@ -114,6 +118,41 @@ namespace Orc.FilterBuilder
 
                 case Condition.LessThanOrEqualTo:
                     return entityValue <= Value;
+
+                default:
+                    throw new NotSupportedException(string.Format("Condition '{0}' is not supported.", SelectedCondition));
+            }
+        }
+
+        /// <summary>
+        ///   Converts <see cref="ConditionTreeItem"/> to a LINQ <see cref="Expression"/>
+        /// </summary>
+        /// <param name="propertyExpr">LINQ <see cref="MemberExpression"/>.</param>
+        /// <returns>LINQ Expression.</returns>
+        public override Expression ToLinqExpression(Expression propertyExpr)
+        {
+            var valueExpr = Expression.Constant(Value, typeof(TimeSpan));
+
+            // Operators
+            switch (SelectedCondition)
+            {
+                case Condition.EqualTo:
+                    return Expression.Equal(propertyExpr, valueExpr);
+
+                case Condition.NotEqualTo:
+                    return Expression.NotEqual(propertyExpr, valueExpr);
+
+                case Condition.GreaterThan:
+                    return Expression.GreaterThan(propertyExpr, valueExpr);
+
+                case Condition.LessThan:
+                    return Expression.LessThan(propertyExpr, valueExpr);
+
+                case Condition.GreaterThanOrEqualTo:
+                    return Expression.GreaterThanOrEqual(propertyExpr, valueExpr);
+
+                case Condition.LessThanOrEqualTo:
+                    return Expression.LessThanOrEqual(propertyExpr, valueExpr);
 
                 default:
                     throw new NotSupportedException(string.Format("Condition '{0}' is not supported.", SelectedCondition));

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/ValueDataTypeExpression.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/ValueDataTypeExpression.cs
@@ -4,13 +4,13 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-
 namespace Orc.FilterBuilder
 {
-    using Models;
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
+    using System.Linq.Expressions;
+
+    using Orc.FilterBuilder.Models;
 
     public abstract class ValueDataTypeExpression<TValue> : NullableDataTypeExpression
         where TValue : struct, IComparable, IFormattable, IConvertible, IComparable<TValue>, IEquatable<TValue>
@@ -19,18 +19,25 @@ namespace Orc.FilterBuilder
         private readonly Comparer<TValue> _comparer;
         #endregion
 
-        protected ValueDataTypeExpression()
-            : base()
+
+
+        #region Constructors
+        protected ValueDataTypeExpression() : base()
         {
             _comparer = Comparer<TValue>.Default;
 
             SelectedCondition = Condition.EqualTo;
             Value = default(TValue);
         }
+        #endregion
+
+
 
         #region Properties
         public TValue Value { get; set; }
         #endregion
+
+
 
         #region Methods
         public override bool CalculateResult(IPropertyMetadata propertyMetadata, object entity)
@@ -94,6 +101,81 @@ namespace Orc.FilterBuilder
                     default:
                         throw new NotSupportedException(string.Format("Condition '{0}' is not supported.", SelectedCondition));
                 }
+            }
+        }
+
+        /// <summary>
+        ///   Converts <see cref="ConditionTreeItem"/> to a LINQ <see cref="Expression"/>
+        /// </summary>
+        /// <param name="propertyExpr">LINQ <see cref="MemberExpression"/>.</param>
+        /// <returns>LINQ Expression.</returns>
+        public override Expression ToLinqExpression(Expression propertyExpr)
+        {
+            Expression valueExpr;
+
+            // Nullable type
+            if (IsNullable)
+            {
+                // Null-Check first
+                switch (SelectedCondition)
+                {
+                    case Condition.IsNull:
+                        return Expression.Equal(propertyExpr, Expression.Constant(null, typeof(TValue?)));
+
+                    case Condition.NotIsNull:
+                        return Expression.NotEqual(propertyExpr, Expression.Constant(null, typeof(TValue?)));
+                }
+
+                // Not null-check
+                valueExpr = Expression.Constant(Value, typeof(TValue?));
+
+                // return CreateNullableOperatorExpression(propertyExpr, valueExpr);
+                return CreateOperatorExpression(propertyExpr, valueExpr);
+            }
+            else
+            {
+                // Not nullable, get provided constant value
+                valueExpr = Expression.Constant(Value, typeof(TValue));
+
+                return CreateOperatorExpression(propertyExpr, valueExpr);
+            }
+        }
+
+        private Expression CreateNullableOperatorExpression(Expression propExpr, Expression valueExpr)
+        {
+            Expression propHasValueExpr = Expression.Property(propExpr, "HasValue");
+            Expression propValueExpr = Expression.Property(propExpr, "Value");
+
+            Expression operatorExpr = CreateOperatorExpression(propValueExpr, valueExpr);
+
+            return Expression.AndAlso(propHasValueExpr, operatorExpr);
+        }
+
+        private Expression CreateOperatorExpression(Expression propertyExpr, Expression valueExpr)
+        {
+            // Operators
+            switch (SelectedCondition)
+            {
+                case Condition.EqualTo:
+                    return Expression.Equal(propertyExpr, valueExpr);
+
+                case Condition.NotEqualTo:
+                    return Expression.NotEqual(propertyExpr, valueExpr);
+
+                case Condition.GreaterThan:
+                    return Expression.GreaterThan(propertyExpr, valueExpr);
+
+                case Condition.LessThan:
+                    return Expression.LessThan(propertyExpr, valueExpr);
+
+                case Condition.GreaterThanOrEqualTo:
+                    return Expression.GreaterThanOrEqual(propertyExpr, valueExpr);
+
+                case Condition.LessThanOrEqualTo:
+                    return Expression.LessThanOrEqual(propertyExpr, valueExpr);
+
+                default:
+                    throw new NotSupportedException(string.Format("Condition '{0}' is not supported.", SelectedCondition));
             }
         }
 

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/ValueDataTypeExpression.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Expressions/ValueDataTypeExpression.cs
@@ -10,6 +10,8 @@ namespace Orc.FilterBuilder
     using System.Collections.Generic;
     using System.Linq.Expressions;
 
+    using Catel;
+
     using Orc.FilterBuilder.Models;
 
     public abstract class ValueDataTypeExpression<TValue> : NullableDataTypeExpression
@@ -111,6 +113,8 @@ namespace Orc.FilterBuilder
         /// <returns>LINQ Expression.</returns>
         public override Expression ToLinqExpression(Expression propertyExpr)
         {
+            Argument.IsNotNull(() => propertyExpr);
+
             Expression valueExpr;
 
             // Nullable type

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Extensions/FilterSchemeExtensions.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Extensions/FilterSchemeExtensions.cs
@@ -4,19 +4,22 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-
 namespace Orc.FilterBuilder
 {
     using System;
     using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
+    using System.Linq.Expressions;
+
     using Catel;
     using Catel.Collections;
     using Catel.Reflection;
+
     using MethodTimer;
-    using Models;
-    using Services;
-    using Catel.Data;
+
+    using Orc.FilterBuilder.Models;
+    using Orc.FilterBuilder.Services;
 
     public static class FilterSchemeExtensions
     {
@@ -24,16 +27,63 @@ namespace Orc.FilterBuilder
         private const string Separator = "||";
         #endregion
 
+
+
         #region Methods
+        /// <summary>
+        ///     Apply current filter to entity and calculate result.
+        /// </summary>
+        /// <param name="f">Filter instance.</param>
+        /// <param name="entity">Object on which to apply filter.</param>
+        /// <returns></returns>
+        public static bool CalculateResult(this FilterScheme f, object entity)
+        {
+            Argument.IsNotNull(() => entity);
+
+            var root = f.Root;
+
+            if (root != null)
+                return root.CalculateResult(entity);
+
+            return true;
+        }
+
+        /// <summary>
+        ///     Convert internal expression tree to Linq expression tree.
+        /// </summary>
+        /// <typeparam name="T">Target type</typeparam>
+        /// <param name="f">Filter instance</param>
+        /// <returns></returns>
+        /// <exception cref="System.InvalidOperationException">Invalid type</exception>
+        [Time]
+        public static Expression<Func<T, bool>> ToLinqExpression<T>(this FilterScheme f)
+        {
+            ParameterExpression parameterExpr = Expression.Parameter(typeof(T), "obj");
+
+            return Expression.Lambda<Func<T, bool>>(f.Root.ToLinqExpression(parameterExpr), parameterExpr);
+        }
+
+        /// <summary>
+        ///     Convert internal expression tree to Linq expression tree.
+        /// </summary>
+        /// <param name="f">Filter instance</param>
+        /// <returns></returns>
+        /// <exception cref="System.InvalidOperationException">Invalid type</exception>
+        [Time]
+        public static LambdaExpression ToLinqExpression(this FilterScheme f)
+        {
+            ParameterExpression parameterExpr = Expression.Parameter(f.TargetType, "obj");
+
+            return Expression.Lambda(f.Root.ToLinqExpression(parameterExpr), parameterExpr);
+        }
+
         public static void EnsureIntegrity(this FilterScheme filterScheme, IReflectionService reflectionService)
         {
             Argument.IsNotNull(() => filterScheme);
             Argument.IsNotNull(() => reflectionService);
 
             foreach (var item in filterScheme.ConditionItems)
-            {
                 item.EnsureIntegrity(reflectionService);
-            }
         }
 
         public static void EnsureIntegrity(this ConditionTreeItem conditionTreeItem, IReflectionService reflectionService)
@@ -42,6 +92,7 @@ namespace Orc.FilterBuilder
             Argument.IsNotNull(() => reflectionService);
 
             var propertyExpression = conditionTreeItem as PropertyExpression;
+
             if (propertyExpression != null)
             {
                 propertyExpression.EnsureIntegrity(reflectionService);
@@ -92,23 +143,25 @@ namespace Orc.FilterBuilder
             Argument.IsNotNull(() => rawCollection);
             Argument.IsNotNull(() => filteredCollection);
 
+            var compiledDelegate = filterScheme.ToLinqExpression().Compile();
+
             IDisposable suspendToken = null;
             if (filteredCollection is ISuspendChangeNotificationsCollection)
-            {
                 suspendToken = ((ISuspendChangeNotificationsCollection)filteredCollection).SuspendChangeNotifications();
-            }
 
             filteredCollection.Clear();
 
-            foreach (var item in rawCollection.Cast<object>().Where(filterScheme.CalculateResult))
-            {
+            foreach (var item in rawCollection.Cast<object>().Where(i => (bool)compiledDelegate.DynamicInvoke(i)))
                 filteredCollection.Add(item);
-            }
+
+#if false
+            foreach (
+                var item in rawCollection.Cast<object>().Where(filterScheme.CalculateResult))
+                filteredCollection.Add(item);
+#endif
 
             if (suspendToken != null)
-            {
                 suspendToken.Dispose();
-            }
         }
         #endregion
     }

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Extensions/FilterSchemeExtensions.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Extensions/FilterSchemeExtensions.cs
@@ -154,12 +154,6 @@ namespace Orc.FilterBuilder
             foreach (var item in rawCollection.Cast<object>().Where(i => (bool)compiledDelegate.DynamicInvoke(i)))
                 filteredCollection.Add(item);
 
-#if false
-            foreach (
-                var item in rawCollection.Cast<object>().Where(filterScheme.CalculateResult))
-                filteredCollection.Add(item);
-#endif
-
             if (suspendToken != null)
                 suspendToken.Dispose();
         }

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Models/FilterScheme.cs
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.Shared/Models/FilterScheme.cs
@@ -1,9 +1,8 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="FilterScheme.cs" company="WildGums">
-//   Copyright (c) 2008 - 2014 WildGums. All rights reserved.
+//   Copyright (c) 2008 - 2016 WildGums. All rights reserved.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-
 
 namespace Orc.FilterBuilder.Models
 {
@@ -164,19 +163,6 @@ namespace Orc.FilterBuilder.Models
             CheckForInvalidItems();
 
             RaiseUpdated();
-        }
-
-        public bool CalculateResult(object entity)
-        {
-            Argument.IsNotNull(() => entity);
-
-            var root = Root;
-            if (root != null)
-            {
-                return root.CalculateResult(entity);
-            }
-
-            return true;
         }
 
         public void Update(FilterScheme otherScheme)


### PR DESCRIPTION
* Added **Expression\<Func\<T, bool\>\> ToLinqExpression\<T\>()** Method which converts a FilterScheme instance to a LINQ Expression.
* Added a simple test to compare ToLinqExpression with ComputeResult results. More tests should be added to make sure all operators are operational.
* **FilterScheme.Apply** uses **ToLinqExpression**.
* TODO: Add Regex and Enum (**StringExpression**) handling in **ToLinqExpression**