### PR TITLE
Updates Fody and Catel.Fody packages

### DIFF
--- a/src/Orc.FilterBuilder.Example/Orc.FilterBuilder.Example.csproj
+++ b/src/Orc.FilterBuilder.Example/Orc.FilterBuilder.Example.csproj
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Catel.Fody" Version="4.10.0" PrivateAssets="all" />
-    <PackageReference Include="Fody" Version="6.9.2" PrivateAssets="all">
+    <PackageReference Include="Catel.Fody" Version="4.9.0" PrivateAssets="all" />
+    <PackageReference Include="Fody" Version="6.9.1" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="LoadAssembliesOnStartup.Fody" Version="4.7.0" PrivateAssets="all" />

--- a/src/Orc.FilterBuilder.Xaml/Orc.FilterBuilder.Xaml.csproj
+++ b/src/Orc.FilterBuilder.Xaml/Orc.FilterBuilder.Xaml.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Catel.Fody" Version="4.10.0" PrivateAssets="all" />
-    <PackageReference Include="Fody" Version="6.9.2" PrivateAssets="all">
+    <PackageReference Include="Catel.Fody" Version="4.9.0" PrivateAssets="all" />
+    <PackageReference Include="Fody" Version="6.9.1" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="MethodTimer.Fody" Version="3.2.3" PrivateAssets="all" />

--- a/src/Orc.FilterBuilder/Conditions/ConditionTreeItem.cs
+++ b/src/Orc.FilterBuilder/Conditions/ConditionTreeItem.cs
@@ -17,7 +17,7 @@ public abstract class ConditionTreeItem : ValidatableModelBase
     [ExcludeFromValidation]
     public bool IsValid { get; private set; } = true;
 
-    public ObservableCollection<ConditionTreeItem> Items { get; } = new();
+    public ObservableCollection<ConditionTreeItem> Items { get; private set; } = new();
 
     public event EventHandler<EventArgs>? Updated;
 

--- a/src/Orc.FilterBuilder/Orc.FilterBuilder.csproj
+++ b/src/Orc.FilterBuilder/Orc.FilterBuilder.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Catel.Fody" Version="4.10.0" PrivateAssets="all" />
-    <PackageReference Include="Fody" Version="6.9.2" PrivateAssets="all">
+    <PackageReference Include="Catel.Fody" Version="4.9.0" PrivateAssets="all" />
+    <PackageReference Include="Fody" Version="6.9.1" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="LoadAssembliesOnStartup.Fody" Version="4.7.0" PrivateAssets="all" />


### PR DESCRIPTION
Updates the Fody and Catel.Fody NuGet packages in the core and example projects.

Also, modifies the `Items` property in `ConditionTreeItem` to have a private setter, ensuring more controlled access.

### Description of Change ###

<!-- Describe your changes here -->

### Issues Resolved ### 

<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###

<!-- List all API changes here (or just put None) -->
 
None

### Behavioral Changes ###

<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###

<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] I have included examples or tests
- [ ] I have updated the change log or created a GitHub ticket with the change
- [ ] I am listed in the CONTRIBUTORS file (if it exists)
- [ ] Changes adhere to coding standard
- [ ] I checked the licenses of Third Party software and discussed new dependencies with at least 1 other team member